### PR TITLE
support printf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ QEMU = qemu-system-riscv64
 
 GDBPORT = 26000
 
-CFLAGS = -std=c17 -Wall -Werror -nostdlib -mcmodel=medany
+CFLAGS = -std=c17 -Wall -Werror -nostdlib -fno-builtin -mcmodel=medany
 QEMUFLAGS = -machine virt -nographic -smp 1 -bios none
 QEMUGDB = -S -gdb tcp::$(GDBPORT)
 

--- a/error.c
+++ b/error.c
@@ -2,9 +2,7 @@
 #include "print.h"
 
 void error(char* reason) {
-  print("Error: ");
-  print(reason);
-  print("\n");
+  printf("Error: %s\n", reason);
 
   for (;;) {
     __asm__ volatile("wfi");

--- a/print.c
+++ b/print.c
@@ -1,8 +1,99 @@
 #include "print.h"
 #include "uart.h"
+#include "vararg.h"
+
+#define OUT_BUFFER_SIZE 1024
+
+static int sprintunum(char *out, unsigned int num);
+static int sprintstr(char *out, char *str);
+
+static char out_buffer[OUT_BUFFER_SIZE];
 
 void print(char *str) {
   for (char *ch = str; *ch != '\0'; ch++) {
     uart_put_char(*ch);
   }
+}
+
+int printf(char *format, ...) {
+  va_list args;
+  va_start(args, format);
+
+  return vprintf(format, args);
+}
+
+int vprintf(char *format, va_list args) {
+  // TODO: error on buffer overflow
+
+  int length = vsprintf(out_buffer, format, args);
+  print(out_buffer);
+
+  return length;
+}
+
+int vsprintf(char *out, char *format, va_list args) {
+  char *out_begin = out;
+  char *ch = format;
+
+  for (;;) {
+    if (*ch == '\0') {
+      *out++ = *ch++;
+      break;
+    }
+
+    if (*ch != '%') {
+      *out++ = *ch++;
+      continue;
+    }
+
+    ch++;
+
+    if (*ch == 'u') {
+      unsigned int num = va_arg(args, unsigned int);
+      int length = sprintunum(out, num);
+
+      out += length;
+      ch++;
+      continue;
+    }
+
+    if (*ch == 's') {
+      char *str = va_arg(args, char *);
+      int length = sprintstr(out, str);
+
+      out += length;
+      ch++;
+      continue;
+    }
+
+    // unexpected format
+    *out++ = *ch++;
+    *out++ = '\0';
+    break;
+  }
+
+  int length = (out-1) - out_begin;
+  return length;
+}
+
+static int sprintunum(char *out, unsigned int num) {
+  if (num < 10) {
+    *out = '0' + num;
+    return 1;
+  }
+
+  int length = sprintunum(out, num / 10);
+  out[length] = '0' + (num % 10);
+
+  return length+1;
+}
+
+static int sprintstr(char *out, char *str) {
+  char *out_begin = out;
+
+  for (char *ch = str; *ch != '\0'; ch++) {
+    *out++ = *str++;
+  }
+
+  return out - out_begin;
 }

--- a/print.c
+++ b/print.c
@@ -9,7 +9,7 @@ static int sprintstr(char *out, char *str);
 
 static char out_buffer[OUT_BUFFER_SIZE];
 
-void print(char *str) {
+void putstr(char *str) {
   for (char *ch = str; *ch != '\0'; ch++) {
     uart_put_char(*ch);
   }
@@ -26,7 +26,7 @@ int vprintf(char *format, va_list args) {
   // TODO: error on buffer overflow
 
   int length = vsprintf(out_buffer, format, args);
-  print(out_buffer);
+  putstr(out_buffer);
 
   return length;
 }

--- a/print.h
+++ b/print.h
@@ -1,6 +1,11 @@
 #ifndef PRINT_H
 #define PRINT_H
 
+#include "vararg.h"
+
 void print(char *str);
+int printf(char *format, ...);
+int vprintf(char *format, va_list args);
+int vsprintf(char *out, char *format, va_list args);
 
 #endif

--- a/print.h
+++ b/print.h
@@ -3,7 +3,7 @@
 
 #include "vararg.h"
 
-void print(char *str);
+void putstr(char *str);
 int printf(char *format, ...);
 int vprintf(char *format, va_list args);
 int vsprintf(char *out, char *format, va_list args);

--- a/start.c
+++ b/start.c
@@ -11,7 +11,7 @@ __attribute__ ((aligned (16))) uint8 stack[STACK_SIZE];
 static void schedule_user_tasks();
 
 void start(void) {
-  print("Booting: OK\n");
+  printf("Booting: OK\n");
 
   init_user_tasks();
   init_trap();

--- a/user_tasks.c
+++ b/user_tasks.c
@@ -15,21 +15,21 @@ void init_user_tasks(void) {
 
 static void user_task1(void) {
   for (;;) {
-    print("1");
+    printf("1");
     delay();
   }
 }
 
 static void user_task2(void) {
   for (;;) {
-    print("2");
+    printf("2");
     delay();
   }
 }
 
 static void user_task3(void) {
   for (;;) {
-    print("3");
+    printf("3");
     delay();
   }
 }

--- a/vararg.h
+++ b/vararg.h
@@ -1,0 +1,9 @@
+#ifndef VARARG_H
+#define VARARG_H
+
+typedef __builtin_va_list va_list;
+
+#define va_start(v, args)  (__builtin_va_start(v, args))
+#define va_arg(v, t)    (__builtin_va_arg(v, t))
+
+#endif


### PR DESCRIPTION
Note: To make a `printf()` function, `-fno-builtin` flag added for `gcc` to avoid using built-in standard `printf()`.